### PR TITLE
Show images for top two looks

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,3 +67,32 @@ if st.button("Сгенерировать лук"):
         else:
             st.subheader(part.capitalize())
             st.dataframe(df_part, use_container_width=True)
+
+    # --- визуализация top-2 луков ---
+    st.markdown("### Top-2 найденных лука")
+    col1, col2 = st.columns(2)
+
+    WIDTH_MAP = {
+        "accessories": 80,
+        "shoes": 120,
+        "bottom": 200,
+        "top": 200,
+        "outerwear": 250,
+        "full": 250,
+    }
+
+    def show_look(col, idx):
+        with col:
+            st.write(f"#### Лук {idx+1}")
+            for part in ["accessories", "outerwear", "top", "bottom", "full", "shoes"]:
+                df_part = results.get(part)
+                if df_part is not None and len(df_part) > idx:
+                    row = df_part.iloc[idx]
+                    url = row.get("image_external_url")
+                    name = row.get("name", part)
+                    if url:
+                        width = WIDTH_MAP.get(part, 200)
+                        st.image(url, caption=f"{part}: {name}", width=width)
+
+    show_look(col1, 0)
+    show_look(col2, 1)


### PR DESCRIPTION
## Summary
- render Top-2 look images in the Streamlit app
- scale item images using a width map so accessories and shoes appear smaller than pants or coats

## Testing
- `python -m py_compile app.py stylist_core.py prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_685af99759d4832499cbfacdee31761d